### PR TITLE
Using "where" instead of "which" on windows

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/Utilities.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/Utilities.scala
@@ -26,8 +26,9 @@ object Utilities {
           case (major, minor) =>
             Seq(s"$binaryName$major$minor", s"$binaryName-$major.$minor")
         } :+ binaryName
-
-        Process("which" +: binaryNames).lines_!
+          
+        val which = if (isWindows) "where" else "which"
+        Process(which +: binaryNames).lines_!
           .map(file(_))
           .headOption
           .getOrElse {


### PR DESCRIPTION
Fixed the issue involving the usage of "which" to find "clang.exe" and "clang++.exe" on windows, which doesn't exist when using cmd.exe, and results in a strange/double drive prefix when using mingw. Using "where" instead results in the correct path.